### PR TITLE
Fixed ther reducer function for multidimentional query params

### DIFF
--- a/src/helpers/reducer.js
+++ b/src/helpers/reducer.js
@@ -6,6 +6,11 @@ module.exports = function (obj, pair) {
     return obj
   }
 
+  if(obj[pair.name] instanceof Array) {
+    obj[pair.name].push(pair.value)
+    return obj
+  }
+
   // convert to array
   var arr = [
     obj[pair.name],

--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -56,7 +56,8 @@ module.exports = function (source, options) {
     default:
       // raw request body
       if (source.postData.text) {
-        code.push('%s %s', opts.short ? '-d' : '--data', helpers.escape(helpers.quote(source.postData.text)))
+        var postData = helpers.quote(source.postData.text);
+        code.push('%s %s', opts.short ? '-d' : '--data', options.escape ? helpers.escape(postData) : postData)
       }
   }
 


### PR DESCRIPTION
Issue:
If the body param has the values
```json
[
  {"name": "key", "value": "value"},
  {"name": "foo", "value": "bar1"},
  {"name": "foo", "value": "bar2"},
  {"name": "foo", "value": "bar3"}
]
```
The reducer function were generating it as, 
```json
{
  "key": "value",
  "foo": [["bar1", "bar2"], "bar3"]
}
```
 
On passing the above value to `qs` module results in `key=value&foo=&foo=bar3`

This fix ensure we are not blindly adding the query params into the array (results in nested array)

hence, the out put of reducer function would be
```json
{
  "key" : "value",
  "foo": ["bar1", "bar2", "bar3"]
} 
```

on passing to `qs` returns `key=value&foo=bar1&foo=bar2&foo=bar3`  which was the desired value.
