### PR TITLE
Bump postman-collection to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "xmlhttprequest"
   ],
   "engines": {
-    "node": ">=0.10"
+    "node": ">=18"
   },
   "files": [
     "bin",
@@ -70,6 +70,6 @@
     "folderify": "^0.7.0",
     "form-data": "^0.2.0",
     "har-validator-fsless": "1.6.6",
-    "postman-collection": "3.0.8"
+    "postman-collection": "5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "glob": "^5.0.3",
     "istanbul": "0.4.5",
     "mocha": "^4.0.0",
+    "require-directory": "^2.1.1",
     "should": "^5.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
- Bump postman-collection to 5.0.0
- Drop support for Node < 18
- Add missing dependency